### PR TITLE
Fix select spacer functionality, Hide/Show text

### DIFF
--- a/src/app/clue-editing/clue-editing.component.html
+++ b/src/app/clue-editing/clue-editing.component.html
@@ -12,7 +12,7 @@
         <div *ngFor="let clue of acrossClues; let i = index" class="form-group">
           <div class="hstack gap-2 p-3">
             <div class="p-1">
-              <strong>{{ acrossClues[i].index }}</strong>
+              <strong>{{ acrossClues[i].num }}</strong>
             </div>
             <div class="vr"></div>
             <div class="p-1">{{ acrossClues[i].answer }}</div>
@@ -35,7 +35,7 @@
         <div *ngFor="let clue of downClues; let i = index" class="form-group">
           <div class="hstack gap-2 p-3">
             <div class="p-1">
-              <strong>{{ downClues[i].index }}</strong>
+              <strong>{{ downClues[i].num }}</strong>
             </div>
             <div class="vr"></div>
             <div class="p-1">{{ downClues[i].answer }}</div>

--- a/src/app/clue-editing/clue-editing.component.ts
+++ b/src/app/clue-editing/clue-editing.component.ts
@@ -37,7 +37,7 @@ export class ClueEditingComponent implements OnInit {
       let clue = this.puzzleService.puzzle.acrossClues[index];
       let text = this.cluesForm.value.across[index];
 
-      this.puzzleService.setClueText(ClueType.Across, clue.index, text);
+      this.puzzleService.setClueText(ClueType.Across, clue.num, text);
       control.markAsPristine();
     }
   }
@@ -49,7 +49,7 @@ export class ClueEditingComponent implements OnInit {
       let clue = this.puzzleService.puzzle.downClues[index];
       let text = this.cluesForm.value.down[index];
 
-      this.puzzleService.setClueText(ClueType.Down, clue.index, text);
+      this.puzzleService.setClueText(ClueType.Down, clue.num, text);
       control.markAsPristine();
     }
   }

--- a/src/app/puzzle-editing/puzzle-editing.component.html
+++ b/src/app/puzzle-editing/puzzle-editing.component.html
@@ -30,7 +30,9 @@
           Intersect
         </button>
       </div>
-      <button class="btn btn-secondary" type="submit" (click)="answersHidden = !answersHidden">Hide Answers</button>
+      <button class="btn btn-secondary" type="submit" (click)="answersHidden = !answersHidden">
+        <span *ngIf="answersHidden">Show</span><span *ngIf="!answersHidden">Hide</span> Answers
+      </button>
       <button class="ms-auto btn btn-success" type="submit" (click)="onSave()">Save</button>
       <button class="btn btn-danger" type="submit" (click)="onClear()">Clear</button>
     </div>

--- a/src/app/puzzle-editing/puzzle-editing.component.ts
+++ b/src/app/puzzle-editing/puzzle-editing.component.ts
@@ -131,7 +131,7 @@ export class PuzzleEditingComponent implements OnInit {
    * @returns true if square should be highlighted, false otherwise
    */
   public isHighlighted(square: Square): boolean {
-    if (this.editMode == EditMode.Value) {
+    if (this.editMode == EditMode.Value && square.type == SquareType.Letter) {
       if (this.highlightMode == HighlightMode.Across) {
         return square.acrossClueNum == this.puzzleGrid[this.selectedIndex].acrossClueNum;
       } else if (this.highlightMode == HighlightMode.Down) {

--- a/src/app/selected-clue/selected-clue.component.html
+++ b/src/app/selected-clue/selected-clue.component.html
@@ -3,7 +3,9 @@
     <div class="p-3">
       <div class="hstack gap-2 p-3">
         <div class="p-1">
-          <strong>{{ acrossClue.index }} Across</strong>
+          <strong
+            ><span *ngIf="acrossClue.num != -1">{{ acrossClue.num }} </span>Across</strong
+          >
         </div>
         <div class="vr"></div>
         <div class="p-1">{{ acrossClue.answer }}</div>
@@ -19,7 +21,9 @@
     <div class="p-3">
       <div class="hstack gap-2 p-3">
         <div class="p-1">
-          <strong>{{ downClue.index }} Down</strong>
+          <strong
+            ><span *ngIf="downClue.num != -1">{{ downClue.num }} </span>Down</strong
+          >
         </div>
         <div class="vr"></div>
         <div class="p-1">{{ downClue.answer }}</div>

--- a/src/app/selected-clue/selected-clue.component.spec.ts
+++ b/src/app/selected-clue/selected-clue.component.spec.ts
@@ -3,31 +3,32 @@ import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 
 import { SelectedClueComponent } from "./selected-clue.component";
 import { BehaviorSubject } from "rxjs";
-import { Clue, ClueType, PuzzleService } from "../services/puzzle.service";
+import { Clue, ClueType, Puzzle, PuzzleService } from "../services/puzzle.service";
 
-describe("ClueListComponent", () => {
+describe("SelectedClueComponent", () => {
   let component: SelectedClueComponent;
   let fixture: ComponentFixture<SelectedClueComponent>;
 
-  const puzzleServiceSpy = jasmine.createSpyObj("PuzzleService", ["activeAcrossClue$", "activeDownClue$", "setClueText"]);
+  const puzzleServiceSpy = jasmine.createSpyObj("PuzzleService", ["puzzle", "activeAcrossClue$", "activeDownClue$", "setClueText"]);
 
   const testAcross: Clue = {
-    index: 1,
+    num: 1,
     text: "Some across clue text",
     answer: "TEST",
     squares: [0, 1, 2, 3],
   };
 
   const testDown: Clue = {
-    index: 1,
+    num: 1,
     text: "Some down clue text",
     answer: "TESTTOO",
     squares: [0, 1, 2, 3, 4, 5, 6],
   };
 
   beforeEach(async () => {
-    puzzleServiceSpy.activeAcrossClue$ = new BehaviorSubject(testAcross);
-    puzzleServiceSpy.activeDownClue$ = new BehaviorSubject(testDown);
+    puzzleServiceSpy.puzzle = { acrossClues: [testAcross], downClues: [testDown] } as Puzzle;
+    puzzleServiceSpy.activeAcrossClue$ = new BehaviorSubject(0);
+    puzzleServiceSpy.activeDownClue$ = new BehaviorSubject(0);
     puzzleServiceSpy.setClueText.and.callFake(() => {});
 
     await TestBed.configureTestingModule({
@@ -40,14 +41,45 @@ describe("ClueListComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(SelectedClueComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
   });
 
+  describe("ngOnInit", () => {
+    it("should set value and enable clues when index != -1", () => {
+      puzzleServiceSpy.activeAcrossClue$.next(0);
+      puzzleServiceSpy.activeDownClue$.next(0);
+
+      fixture.detectChanges();
+
+      expect(component.acrossInput.disabled).toBeFalsy();
+      expect(component.downInput.disabled).toBeFalsy();
+
+      expect(component.acrossInput.value).toEqual(testAcross.text);
+      expect(component.downInput.value).toEqual(testDown.text);
+    });
+
+    it("should reset and disable clues when index == -1", () => {
+      puzzleServiceSpy.activeAcrossClue$.next(-1);
+      puzzleServiceSpy.activeDownClue$.next(-1);
+
+      fixture.detectChanges();
+
+      expect(component.acrossInput.disabled).toBeTruthy();
+      expect(component.downInput.disabled).toBeTruthy();
+
+      expect(component.acrossInput.value).toBeNull();
+      expect(component.downInput.value).toBeNull();
+    });
+  });
+
   describe("saveClues", () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
     it("should set clue text and mark across input as pristine", () => {
       component.acrossInput.setValue("Some new text");
       component.acrossInput.markAsDirty();

--- a/src/app/selected-clue/selected-clue.component.ts
+++ b/src/app/selected-clue/selected-clue.component.ts
@@ -17,25 +17,39 @@ export class SelectedClueComponent implements OnInit {
   constructor(private puzzleService: PuzzleService) {}
 
   ngOnInit(): void {
-    this.puzzleService.activeAcrossClue$.subscribe((clue: Clue) => {
-      this.acrossClue = clue;
-      this.acrossInput.setValue(clue.text);
+    this.puzzleService.activeAcrossClue$.subscribe((index: number) => {
+      if (index != -1) {
+        this.acrossClue = this.puzzleService.puzzle.acrossClues[index];
+        this.acrossInput.setValue(this.acrossClue.text);
+        this.acrossInput.enable();
+      } else {
+        this.acrossClue = new Clue();
+        this.acrossInput.reset();
+        this.acrossInput.disable();
+      }
     });
 
-    this.puzzleService.activeDownClue$.subscribe((clue: Clue) => {
-      this.downClue = clue;
-      this.downInput.setValue(clue.text);
+    this.puzzleService.activeDownClue$.subscribe((index: number) => {
+      if (index != -1) {
+        this.downClue = this.puzzleService.puzzle.downClues[index];
+        this.downInput.setValue(this.downClue.text);
+        this.downInput.enable();
+      } else {
+        this.downClue = new Clue();
+        this.downInput.reset();
+        this.downInput.disable();
+      }
     });
   }
 
   public saveClues(): void {
     if (this.acrossInput.dirty) {
-      this.puzzleService.setClueText(ClueType.Across, this.acrossClue.index, this.acrossInput.value);
+      this.puzzleService.setClueText(ClueType.Across, this.acrossClue.num, this.acrossInput.value);
       this.acrossInput.markAsPristine();
     }
 
     if (this.downInput.dirty) {
-      this.puzzleService.setClueText(ClueType.Down, this.downClue.index, this.downInput.value);
+      this.puzzleService.setClueText(ClueType.Down, this.downClue.num, this.downInput.value);
       this.downInput.markAsPristine();
     }
   }

--- a/src/app/services/puzzle.service.spec.ts
+++ b/src/app/services/puzzle.service.spec.ts
@@ -125,13 +125,17 @@ describe("PuzzleService", () => {
         expect(service.puzzle.grid[0]).toEqual(new Square(0, " ", 1, 1, 1));
         expect(service.puzzle.grid[8]).toEqual(new Square(8, " ", 9, 1, 9));
 
-        service.activeAcrossClue$.subscribe((clue) => {
-          expect(clue.index).toEqual(1);
+        service.activeAcrossClue$.subscribe((clueIndex) => {
+          const clue = service.puzzle.acrossClues[clueIndex];
+
+          expect(clue.num).toEqual(1);
           expect(clue.answer).toEqual(Array(21).fill(" ").join(""));
         });
 
-        service.activeDownClue$.subscribe((clue) => {
-          expect(clue.index).toEqual(1);
+        service.activeDownClue$.subscribe((clueIndex) => {
+          const clue = service.puzzle.downClues[clueIndex];
+
+          expect(clue.num).toEqual(1);
           expect(clue.answer).toEqual(Array(21).fill(" ").join(""));
         });
       });
@@ -143,12 +147,12 @@ describe("PuzzleService", () => {
       service.loadPuzzle(testPuzzleId).subscribe(() => {
         service.selectSquare(3);
 
-        service.activeAcrossClue$.subscribe((clue) => {
-          expect(clue).toEqual(new Clue(1, "It's not that simple", "YESANDNO", [0, 1, 2, 3, 4, 5, 6, 7]));
+        service.activeAcrossClue$.subscribe((clueIndex) => {
+          expect(service.puzzle.acrossClues[clueIndex]).toEqual(new Clue(1, "It's not that simple", "YESANDNO", [0, 1, 2, 3, 4, 5, 6, 7]));
         });
 
-        service.activeDownClue$.subscribe((clue) => {
-          expect(clue).toEqual(new Clue(4, "Draw", "ATTRACT", [3, 24, 45, 66, 87, 108, 129]));
+        service.activeDownClue$.subscribe((clueIndex) => {
+          expect(service.puzzle.downClues[clueIndex]).toEqual(new Clue(4, "Draw", "ATTRACT", [3, 24, 45, 66, 87, 108, 129]));
         });
       });
     });
@@ -157,12 +161,12 @@ describe("PuzzleService", () => {
       service.loadPuzzle(testPuzzleId).subscribe(() => {
         service.selectSquare(432);
 
-        service.activeAcrossClue$.subscribe((clue) => {
-          // TODO: not really sure what behavior I want here (do with bug #13)
+        service.activeAcrossClue$.subscribe((clueIndex) => {
+          expect(clueIndex).toEqual(-1);
         });
 
-        service.activeDownClue$.subscribe((clue) => {
-          // TODO: not really sure what behavior I want here
+        service.activeDownClue$.subscribe((clueIndex) => {
+          expect(clueIndex).toEqual(-1);
         });
       });
     });
@@ -283,12 +287,12 @@ describe("PuzzleService", () => {
 
         expect(service.puzzle.grid[23].value).toEqual("X");
 
-        service.activeAcrossClue$.subscribe((clue) => {
-          expect(clue.answer).toEqual("IDXTAROD");
+        service.activeAcrossClue$.subscribe((clueIndex) => {
+          expect(service.puzzle.acrossClues[clueIndex].answer).toEqual("IDXTAROD");
         });
 
-        service.activeDownClue$.subscribe((clue) => {
-          expect(clue.answer).toEqual("SXRE");
+        service.activeDownClue$.subscribe((clueIndex) => {
+          expect(service.puzzle.downClues[clueIndex].answer).toEqual("SXRE");
         });
       });
     });
@@ -299,12 +303,12 @@ describe("PuzzleService", () => {
 
         expect(service.puzzle.grid[440].value).toEqual(" ");
 
-        service.activeAcrossClue$.subscribe((clue) => {
-          expect(clue.answer).toEqual("TOTHEMA ");
+        service.activeAcrossClue$.subscribe((clueIndex) => {
+          expect(service.puzzle.acrossClues[clueIndex].answer).toEqual("TOTHEMA ");
         });
 
-        service.activeDownClue$.subscribe((clue) => {
-          expect(clue.answer).toEqual("SE ");
+        service.activeDownClue$.subscribe((clueIndex) => {
+          expect(service.puzzle.downClues[clueIndex].answer).toEqual("SE ");
         });
       });
     });


### PR DESCRIPTION
- Fix spacer selection functionality to not highlight any other squares, reset, and disable selected clue inputs
- Change across/down clue BehaviorSubjects to emit clue indices rather than clues
- Change "Hide Answers" text to "Show Answers" when hidden

Resolves: #13, #17, #26   